### PR TITLE
Issue/9

### DIFF
--- a/gson/src/main/java/com/google/gson/FileAppender.java
+++ b/gson/src/main/java/com/google/gson/FileAppender.java
@@ -11,8 +11,6 @@ import java.io.PrintWriter;
  */
 public class FileAppender {
 
-    // PrintWriter solution largely based on SO question at:
-    // https://stackoverflow.com/questions/4614227/how-to-add-a-new-line-of-text-to-an-existing-file-in-java
     String filepath;
 
     /**
@@ -30,6 +28,8 @@ public class FileAppender {
      * @param x the integer to write.
      */
     public void appendInt(int x) {
+        // PrintWriter solution largely based on SO question at:
+        // https://stackoverflow.com/questions/4614227/how-to-add-a-new-line-of-text-to-an-existing-file-in-java
         PrintWriter printWriter;
         try {
             File coverageFile = new File(filepath);

--- a/gson/src/main/java/com/google/gson/FileAppender.java
+++ b/gson/src/main/java/com/google/gson/FileAppender.java
@@ -11,7 +11,7 @@ import java.io.PrintWriter;
  */
 public class FileAppender {
 
-    String filepath;
+    private String filepath;
 
     /**
      * Creates a FileAppender which will attempt to write to the file specified.

--- a/gson/src/main/java/com/google/gson/FileAppender.java
+++ b/gson/src/main/java/com/google/gson/FileAppender.java
@@ -1,0 +1,50 @@
+package com.google.gson;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+
+/**
+ * The FileAppender class is used to append ints as single lines to a file. It is constructed
+ * using a filepath and creates the file at the filepath if needed. Any writes to a closed
+ * FileAppender will result in unspecified behaviour.
+ */
+public class FileAppender {
+
+    // PrintWriter solution largely based on SO question at:
+    // https://stackoverflow.com/questions/4614227/how-to-add-a-new-line-of-text-to-an-existing-file-in-java
+    PrintWriter printWriter;
+
+    /**
+     * Creates a FileAppender which will attempt to write to the file specified.
+     * Creates the file at the filepath if it does not exist.
+     * @param filePath The file to append lines to.
+     */
+    public FileAppender(String filePath) {
+        try {
+            File coverageFile = new File(filePath);
+            coverageFile.createNewFile(); // create file if it does not exist
+            FileWriter fw = new FileWriter(coverageFile, true); // appends to file
+            printWriter = new PrintWriter(fw, true); // automatic flush on
+        } catch (Exception e) {
+            System.out.println("FAILED TO SET UP TEMP FILE WRITER");
+            throw new RuntimeException("FAILED TO SET UP TEMP FILE WRITER", e);
+        }
+    }
+
+    /**
+     * Appends an int to the end of the current file as a single line.
+     * This method will not throw an exception if the FileAppender has been closed.
+     * @param x the integer to write.
+     */
+    public void appendInt(int x) {
+        printWriter.println(x);
+    }
+
+    /**
+     * Closes the underlying PrintWriter. Call when done with this instance.
+     */
+    public void close() {
+        printWriter.close();
+    }
+}

--- a/gson/src/main/java/com/google/gson/FileAppender.java
+++ b/gson/src/main/java/com/google/gson/FileAppender.java
@@ -13,7 +13,7 @@ public class FileAppender {
 
     // PrintWriter solution largely based on SO question at:
     // https://stackoverflow.com/questions/4614227/how-to-add-a-new-line-of-text-to-an-existing-file-in-java
-    PrintWriter printWriter;
+    String filepath;
 
     /**
      * Creates a FileAppender which will attempt to write to the file specified.
@@ -21,15 +21,7 @@ public class FileAppender {
      * @param filePath The file to append lines to.
      */
     public FileAppender(String filePath) {
-        try {
-            File coverageFile = new File(filePath);
-            coverageFile.createNewFile(); // create file if it does not exist
-            FileWriter fw = new FileWriter(coverageFile, true); // appends to file
-            printWriter = new PrintWriter(fw, true); // automatic flush on
-        } catch (Exception e) {
-            System.out.println("FAILED TO SET UP TEMP FILE WRITER");
-            throw new RuntimeException("FAILED TO SET UP TEMP FILE WRITER", e);
-        }
+        this.filepath = filePath;
     }
 
     /**
@@ -38,13 +30,17 @@ public class FileAppender {
      * @param x the integer to write.
      */
     public void appendInt(int x) {
+        PrintWriter printWriter;
+        try {
+            File coverageFile = new File(filepath);
+            coverageFile.createNewFile(); // create file if it does not exist
+            FileWriter fw = new FileWriter(coverageFile, true); // appends to file
+            printWriter = new PrintWriter(fw, true); // automatic flush on
+        } catch (Exception e) {
+            System.out.println("FAILED TO SET UP TEMP FILE WRITER");
+            throw new RuntimeException("FAILED TO SET UP TEMP FILE WRITER", e);
+        }
         printWriter.println(x);
-    }
-
-    /**
-     * Closes the underlying PrintWriter. Call when done with this instance.
-     */
-    public void close() {
         printWriter.close();
     }
 }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1505,6 +1505,7 @@ public class JsonReader implements Closeable {
     char escaped = buffer[pos++];
     switch (escaped) {
     case 'u':
+      fileAppender.appendInt(10);
       if (pos + 4 > limit && !fillBuffer(4)) {
         fileAppender.appendInt(2);
         throw syntaxError("Unterminated escape sequence");
@@ -1535,32 +1536,43 @@ public class JsonReader implements Closeable {
       return result;
 
     case 't':
+      fileAppender.appendInt(11);
       return '\t';
 
     case 'b':
+      fileAppender.appendInt(12);
       return '\b';
 
     case 'n':
+      fileAppender.appendInt(13);
       return '\n';
 
     case 'r':
+      fileAppender.appendInt(14);
       return '\r';
 
     case 'f':
+      fileAppender.appendInt(15);
       return '\f';
 
     case '\n':
+      fileAppender.appendInt(16);
       lineNumber++;
       lineStart = pos;
       // fall-through
 
     case '\'':
+      fileAppender.appendInt(17);
     case '"':
+      fileAppender.appendInt(18);
     case '\\':
-    case '/':	
+      fileAppender.appendInt(19);
+    case '/':
+      fileAppender.appendInt(20);
     	return escaped;
     default:
     	// throw error when none of the above cases are matched
+      fileAppender.appendInt(21);
     	throw syntaxError("Invalid escape sequence");
     }
   }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -16,12 +16,11 @@
 
 package com.google.gson.stream;
 
+import com.google.gson.FileAppender;
 import com.google.gson.internal.JsonReaderInternalAccess;
 import com.google.gson.internal.bind.JsonTreeReader;
-import java.io.Closeable;
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.Reader;
+
+import java.io.*;
 import java.util.Arrays;
 
 /**
@@ -1495,31 +1494,47 @@ public class JsonReader implements Closeable {
    *     malformed.
    */
   private char readEscapeCharacter() throws IOException {
+    // Initiate file adapter to gather branch info
+    FileAppender fileAppender = new FileAppender("./coverage_readEscapeCharacter");
     if (pos == limit && !fillBuffer(1)) {
+      fileAppender.appendInt(0);
+      fileAppender.close();
       throw syntaxError("Unterminated escape sequence");
     }
+    fileAppender.appendInt(1);
 
     char escaped = buffer[pos++];
     switch (escaped) {
     case 'u':
       if (pos + 4 > limit && !fillBuffer(4)) {
+        fileAppender.appendInt(2);
+        fileAppender.close();
         throw syntaxError("Unterminated escape sequence");
       }
+      fileAppender.appendInt(3);
       // Equivalent to Integer.parseInt(stringPool.get(buffer, pos, 4), 16);
       char result = 0;
       for (int i = pos, end = i + 4; i < end; i++) {
+        fileAppender.appendInt(4);
         char c = buffer[i];
         result <<= 4;
         if (c >= '0' && c <= '9') {
+          fileAppender.appendInt(5);
           result += (c - '0');
         } else if (c >= 'a' && c <= 'f') {
+          fileAppender.appendInt(6);
           result += (c - 'a' + 10);
         } else if (c >= 'A' && c <= 'F') {
+          fileAppender.appendInt(7);
           result += (c - 'A' + 10);
         } else {
+          fileAppender.appendInt(8);
+          fileAppender.close();
           throw new NumberFormatException("\\u" + new String(buffer, pos, 4));
         }
       }
+      fileAppender.appendInt(9);
+      fileAppender.close();
       pos += 4;
       return result;
 

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1498,7 +1498,6 @@ public class JsonReader implements Closeable {
     FileAppender fileAppender = new FileAppender("./coverage_readEscapeCharacter");
     if (pos == limit && !fillBuffer(1)) {
       fileAppender.appendInt(0);
-      fileAppender.close();
       throw syntaxError("Unterminated escape sequence");
     }
     fileAppender.appendInt(1);
@@ -1508,7 +1507,6 @@ public class JsonReader implements Closeable {
     case 'u':
       if (pos + 4 > limit && !fillBuffer(4)) {
         fileAppender.appendInt(2);
-        fileAppender.close();
         throw syntaxError("Unterminated escape sequence");
       }
       fileAppender.appendInt(3);
@@ -1529,12 +1527,10 @@ public class JsonReader implements Closeable {
           result += (c - 'A' + 10);
         } else {
           fileAppender.appendInt(8);
-          fileAppender.close();
           throw new NumberFormatException("\\u" + new String(buffer, pos, 4));
         }
       }
       fileAppender.appendInt(9);
-      fileAppender.close();
       pos += 4;
       return result;
 


### PR DESCRIPTION
Solves #9. 

Implement ad hoc branch coverage measurement of `JsonReader::readEscapesCharacter`. Uses `FileAppender` (#13) to print to a file named `coverage_readEscapesCharacter` as soon as a branch has been passed. The DIY coverage measurement only counts branches such as switch cases (including default case), if-else, if-elseif-else and for-loops.

Jacoco 83% branch coverage (26/31). 
DIY 100% coverage (22/22). 