### PR TITLE
fix #23

### DIFF
--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -245,6 +245,13 @@ public class JsonPrimitiveTest extends TestCase {
     assertFalse(new JsonPrimitive(0).equals(new JsonPrimitive(1)));
   }
 
+  // Asserts that an ordinary double is not considered equal to a NaN double
+  // for both possible orderings.
+  public void testEqualsNanAndDouble() {
+    assertFalse(new JsonPrimitive(Double.NaN).equals(new JsonPrimitive(Double.valueOf(-1.2D))));
+    assertFalse(new JsonPrimitive(Double.valueOf(5.1D)).equals(new JsonPrimitive(Double.NaN)));
+  }
+
   public void testEqualsAcrossTypes() {
     MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive("a"), new JsonPrimitive('a'));
     MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(new BigInteger("0")), new JsonPrimitive(0));

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -246,7 +246,8 @@ public class JsonPrimitiveTest extends TestCase {
   }
 
   // Asserts that an ordinary double is not considered equal to a NaN double
-  // for both possible orderings.
+  // for both possible orderings. This test was largely based on other tests 
+  // in this file. 
   public void testEqualsNanAndDouble() {
     assertFalse(new JsonPrimitive(Double.NaN).equals(new JsonPrimitive(Double.valueOf(-1.2D))));
     assertFalse(new JsonPrimitive(Double.valueOf(5.1D)).equals(new JsonPrimitive(Double.NaN)));


### PR DESCRIPTION
Add a test for the JsonPrimitive.equals method asserting that a NaN double is not equal to a correct double. Resolves #23.