### PR TITLE
Issue/26

### DIFF
--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
@@ -79,14 +79,19 @@ public final class LinkedTreeMapTest extends TestCase {
   // comparator has been supplied. This test was largely based on other
   // tests in this file.
   public void testFindWithSpecialComparator() {
-    Comparator comparator = Comparator.reverseOrder();
+    Comparator<String> comparator = new Comparator<String>() {
+      @Override
+      public int compare(String s, String t1) {
+        return s.compareTo(t1);
+      }
+    };
     LinkedTreeMap<String, String> map = new LinkedTreeMap<String, String>(comparator);
-    map.put("a", "android");
+    map.put("aaaaaaa", "android");
     map.put("i", "iOS");
-    map.put("p", "PC");
-    assertEquals("android", map.find("a", false).getValue());
+    map.put("pp", "PC");
+    assertEquals("android", map.find("aaaaaaa", false).getValue());
     assertEquals("iOS", map.find("i", false).getValue());
-    assertEquals("PC", map.find("p", false).getValue());
+    assertEquals("PC", map.find("pp", false).getValue());
   }
 
   public void testPutOverrides() throws Exception {

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
@@ -16,11 +16,7 @@
 
 package com.google.gson.internal;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 import junit.framework.TestCase;
 
@@ -77,6 +73,20 @@ public final class LinkedTreeMapTest extends TestCase {
     LinkedTreeMap<String, String> map = new LinkedTreeMap<String, String>();
     map.put("a", "android");
     assertFalse(map.containsKey(null));
+  }
+
+  // Asserts that the find method finds inserted elements when a custom
+  // comparator has been supplied. This test was largely based on other
+  // tests in this file.
+  public void testFindWithSpecialComparator() {
+    Comparator comparator = Comparator.reverseOrder();
+    LinkedTreeMap<String, String> map = new LinkedTreeMap<String, String>(comparator);
+    map.put("a", "android");
+    map.put("i", "iOS");
+    map.put("p", "PC");
+    assertEquals("android", map.find("a", false).getValue());
+    assertEquals("iOS", map.find("i", false).getValue());
+    assertEquals("PC", map.find("p", false).getValue());
   }
 
   public void testPutOverrides() throws Exception {


### PR DESCRIPTION
This branch adds a test which increases the coverage to 100% (22/22) increased from what is stated in #26 for the `LinkedTreeMap.find(K, boolean)` method. Resolves #26. 