### PR TITLE
Issue/5

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -16,17 +16,14 @@
 
 package com.google.gson.internal;
 
-import com.google.gson.ExclusionStrategy;
-import com.google.gson.FieldAttributes;
-import com.google.gson.Gson;
-import com.google.gson.TypeAdapter;
-import com.google.gson.TypeAdapterFactory;
+import com.google.gson.*;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.Since;
 import com.google.gson.annotations.Until;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -148,7 +145,9 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     };
   }
 
+
   public boolean excludeField(Field field, boolean serialize) {
+
     if ((modifiers & field.getModifiers()) != 0) {
       return true;
     }
@@ -174,8 +173,8 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     }
 
     if (isAnonymousOrLocal(field.getType())) {
-      return true;
-    }
+      return true;}
+
 
     List<ExclusionStrategy> list = serialize ? serializationStrategies : deserializationStrategies;
     if (!list.isEmpty()) {
@@ -200,6 +199,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       }
 
       if (isAnonymousOrLocal(clazz)) {
+
           return true;
       }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -180,6 +180,7 @@ public class ISO8601Utils
                             int parseEndOffset = Math.min(endOffset, offset + 3); // parse up to 3 digits
                             int fraction = parseInt(date, offset, parseEndOffset);
                             // compensate for "missing" digits
+                            // Switch case is never set to 2 and 1 , there this case is never tested in DefaultDateTypeAdapterTest.java.
                             switch (parseEndOffset - offset) { // number of digits parsed
                             case 2:
                                 milliseconds = fraction * 10;
@@ -341,7 +342,7 @@ public class ISO8601Utils
     /**
      * Returns the index of the first character in the string that is not a digit, starting at offset.
      */
-    private static int indexOfNonDigit(String string, int offset) {
+    public static int indexOfNonDigit(String string, int offset) {
         for (int i = offset; i < string.length(); i++) {
             char c = string.charAt(i);
             if (c < '0' || c > '9') return i;

--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -342,7 +342,7 @@ public class ISO8601Utils
     /**
      * Returns the index of the first character in the string that is not a digit, starting at offset.
      */
-    public static int indexOfNonDigit(String string, int offset) {
+    private static int indexOfNonDigit(String string, int offset) {
         for (int i = offset; i < string.length(); i++) {
             char c = string.charAt(i);
             if (c < '0' || c > '9') return i;

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -138,23 +138,6 @@ public class DefaultDateTypeAdapterTest extends TestCase {
     }
   }
 
-  /**
-   * Added tests to increase coverage for the function parse in src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java.
-   * The requirements for triggering the uncovered switch-cases are that (parseEndOffset - offset) is either 1 or 2.
-   * parseEndOffset is calculated asMath.min(endOffset, offset + 3) -
-   * - which chooses the minimum of the offset to the last letter and the offset +3.
-   * First assert results in an (parseEndOffset - offset) value of 2 which results in switch case 2.
-   * Second assert results in an (parseEndOffset - offset) value of 1 which results in switch case 1.
-   * Both are parsed to the format of a DefaultDateTypeAdapter, despite the length.
-   * @throws Exception
-   */
-  public void testIncreaseCoverageParseMethod()throws Exception {
-    DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
-    //Two added tests for coverage
-    assertParsed("1970-01-01T00:00:00.00Z", adapter);
-    assertParsed("1970-01-01T00:00:00.0Z", adapter);
-  };
-
   public void testDateDeserializationISO8601() throws Exception {
     DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
     assertParsed("1970-01-01T00:00:00.000Z", adapter);
@@ -205,6 +188,24 @@ public class DefaultDateTypeAdapterTest extends TestCase {
       fail("Unexpected token should fail.");
     } catch (IllegalStateException expected) { }
   }
+
+  /**
+   * Added tests to increase coverage for the function parse in src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java.
+   * The requirements for triggering the uncovered switch-cases are that (parseEndOffset - offset) is either 1 or 2.
+   * parseEndOffset is calculated asMath.min(endOffset, offset + 3) -
+   * - which chooses the minimum of the offset to the last letter and the offset +3.
+   * First assert results in an (parseEndOffset - offset) value of 2 which results in switch case 2.
+   * Second assert results in an (parseEndOffset - offset) value of 1 which results in switch case 1.
+   * Both are parsed to the format of a DefaultDateTypeAdapter, despite the length.
+   * Expected: Date format parsed to the format of DefaultDateTypeAdapter.
+   * @throws Exception
+   */
+  public void testIncreaseCoverageParseMethod()throws Exception {
+    DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
+    //Two added tests for coverage
+    assertParsed("1970-01-01T00:00:00.00Z", adapter);
+    assertParsed("1970-01-01T00:00:00.0Z", adapter);
+  };
 
   private void assertFormatted(String formatted, DefaultDateTypeAdapter adapter) {
     assertEquals(toLiteral(formatted), adapter.toJson(new Date(0)));

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -26,8 +26,6 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import static com.google.gson.internal.bind.util.ISO8601Utils.indexOfNonDigit;
-
 /**
  * A simple unit test for the {@link DefaultDateTypeAdapter} class.
  *
@@ -140,16 +138,25 @@ public class DefaultDateTypeAdapterTest extends TestCase {
     }
   }
 
+  /**
+   * Added tests to increase coverage for the function parse in src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java.
+   * The requirements for triggering the uncovered switch-cases are that (parseEndOffset - offset) is either 1 or 2.
+   * parseEndOffset is calculated asMath.min(endOffset, offset + 3) -
+   * - which chooses the minimum of the offset to the last number and the offset +3.
+   * First assert results in an (parseEndOffset - offset) value of 2 which results in switch case 2.
+   * Second assert results in an (parseEndOffset - offset) value of 1 which results in switch case 1.
+   * Both are parsed to the format of a DefaultDateTypeAdapter, despite the length.
+   * @throws Exception
+   */
   public void testIncreaseCoverageParseMethod()throws Exception {
-
-  };
-
-  public void testDateDeserializationISO8601() throws Exception {
     DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
     //Two added tests for coverage
     assertParsed("1970-01-01T00:00:00.00Z", adapter);
     assertParsed("1970-01-01T00:00:00.0Z", adapter);
-    //
+  };
+
+  public void testDateDeserializationISO8601() throws Exception {
+    DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
     assertParsed("1970-01-01T00:00:00.000Z", adapter);
     assertParsed("1970-01-01T00:00Z", adapter);
     assertParsed("1970-01-01T00:00:00+00:00", adapter);
@@ -206,12 +213,6 @@ public class DefaultDateTypeAdapterTest extends TestCase {
   private void assertParsed(String date, DefaultDateTypeAdapter adapter) throws IOException {
     assertEquals(date, new Date(0), adapter.fromJson(toLiteral(date)));
     assertEquals("ISO 8601", new Date(0), adapter.fromJson(toLiteral("1970-01-01T00:00:00Z")));
-  }
-
-  public static void main(String[] args) {
-    int endOffset = indexOfNonDigit("1970-01-01T00:00:00:00Z", 20 + 1);
-    System.out.println(endOffset);
-
   }
 
   private static String toLiteral(String s) {

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -142,7 +142,7 @@ public class DefaultDateTypeAdapterTest extends TestCase {
    * Added tests to increase coverage for the function parse in src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java.
    * The requirements for triggering the uncovered switch-cases are that (parseEndOffset - offset) is either 1 or 2.
    * parseEndOffset is calculated asMath.min(endOffset, offset + 3) -
-   * - which chooses the minimum of the offset to the last number and the offset +3.
+   * - which chooses the minimum of the offset to the last letter and the offset +3.
    * First assert results in an (parseEndOffset - offset) value of 2 which results in switch case 2.
    * Second assert results in an (parseEndOffset - offset) value of 1 which results in switch case 1.
    * Both are parsed to the format of a DefaultDateTypeAdapter, despite the length.

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -193,18 +193,26 @@ public class DefaultDateTypeAdapterTest extends TestCase {
    * Added tests to increase coverage for the function parse in src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java.
    * The requirements for triggering the uncovered switch-cases are that (parseEndOffset - offset) is either 1 or 2.
    * parseEndOffset is calculated asMath.min(endOffset, offset + 3) -
-   * - which chooses the minimum of the offset to the last letter and the offset +3.
+   * which chooses the minimum of the offset to the last letter and the offset +3.
    * First assert results in an (parseEndOffset - offset) value of 2 which results in switch case 2.
    * Second assert results in an (parseEndOffset - offset) value of 1 which results in switch case 1.
    * Both are parsed to the format of a DefaultDateTypeAdapter, despite the length.
    * Expected: Date format parsed to the format of DefaultDateTypeAdapter.
    * @throws Exception
    */
-  public void testIncreaseCoverageParseMethod()throws Exception {
+  public void testParseMethodDouble()throws Exception {
+    //Arrange
+    DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
+    //Act, Assert
+    assertParsed("1970-01-01T00:00:00.00Z", adapter);
+
+  };
+  public void testParseMethodSingle()throws Exception {
+    //Arrange
     DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
     //Two added tests for coverage
-    assertParsed("1970-01-01T00:00:00.00Z", adapter);
     assertParsed("1970-01-01T00:00:00.0Z", adapter);
+
   };
 
   private void assertFormatted(String formatted, DefaultDateTypeAdapter adapter) {

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -16,6 +16,9 @@
 
 package com.google.gson;
 
+import com.google.gson.internal.JavaVersion;
+import junit.framework.TestCase;
+
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -23,9 +26,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import com.google.gson.internal.JavaVersion;
-
-import junit.framework.TestCase;
+import static com.google.gson.internal.bind.util.ISO8601Utils.indexOfNonDigit;
 
 /**
  * A simple unit test for the {@link DefaultDateTypeAdapter} class.
@@ -139,8 +140,16 @@ public class DefaultDateTypeAdapterTest extends TestCase {
     }
   }
 
+  public void testIncreaseCoverageParseMethod()throws Exception {
+
+  };
+
   public void testDateDeserializationISO8601() throws Exception {
     DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
+    //Two added tests for coverage
+    assertParsed("1970-01-01T00:00:00.00Z", adapter);
+    assertParsed("1970-01-01T00:00:00.0Z", adapter);
+    //
     assertParsed("1970-01-01T00:00:00.000Z", adapter);
     assertParsed("1970-01-01T00:00Z", adapter);
     assertParsed("1970-01-01T00:00:00+00:00", adapter);
@@ -199,7 +208,14 @@ public class DefaultDateTypeAdapterTest extends TestCase {
     assertEquals("ISO 8601", new Date(0), adapter.fromJson(toLiteral("1970-01-01T00:00:00Z")));
   }
 
+  public static void main(String[] args) {
+    int endOffset = indexOfNonDigit("1970-01-01T00:00:00:00Z", 20 + 1);
+    System.out.println(endOffset);
+
+  }
+
   private static String toLiteral(String s) {
     return '"' + s + '"';
   }
 }
+

--- a/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
@@ -28,13 +28,6 @@ import java.lang.reflect.Field;
  *
  * @author Joel Leitch
  */
-class ClassWithNoFields {
-  // Nothing here..
-  @Override
-  public boolean equals(Object other) {
-    return other.getClass() == TestTypes.ClassWithNoFields.class;
-  }
-}
 
 public class ExposeAnnotationExclusionStrategyTest extends TestCase {
   private Excluder excluder = Excluder.DEFAULT.excludeFieldsWithoutExposeAnnotation();

--- a/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
@@ -17,7 +17,7 @@
 package com.google.gson;
 
 import com.google.gson.annotations.Expose;
-
+import com.google.gson.common.TestTypes;
 import com.google.gson.internal.Excluder;
 import junit.framework.TestCase;
 
@@ -28,6 +28,14 @@ import java.lang.reflect.Field;
  *
  * @author Joel Leitch
  */
+class ClassWithNoFields {
+  // Nothing here..
+  @Override
+  public boolean equals(Object other) {
+    return other.getClass() == TestTypes.ClassWithNoFields.class;
+  }
+}
+
 public class ExposeAnnotationExclusionStrategyTest extends TestCase {
   private Excluder excluder = Excluder.DEFAULT.excludeFieldsWithoutExposeAnnotation();
 
@@ -66,6 +74,7 @@ public class ExposeAnnotationExclusionStrategyTest extends TestCase {
     assertTrue(excluder.excludeField(f, false));
   }
 
+
   private static Field createFieldAttributes(String fieldName) throws Exception {
     return MockObject.class.getField(fieldName);
   }
@@ -85,5 +94,6 @@ public class ExposeAnnotationExclusionStrategyTest extends TestCase {
     public final int explicitlyDifferentModeField = 0;
 
     public final int hiddenField = 0;
+    public final Class<? extends Object> obj = new Object() {}.getClass();
   }
 }

--- a/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
@@ -94,6 +94,5 @@ public class ExposeAnnotationExclusionStrategyTest extends TestCase {
     public final int explicitlyDifferentModeField = 0;
 
     public final int hiddenField = 0;
-    public final Class<? extends Object> obj = new Object() {}.getClass();
   }
 }

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -16,15 +16,14 @@
 
 package com.google.gson;
 
-import java.io.CharArrayReader;
-import java.io.CharArrayWriter;
-import java.io.StringReader;
-
-import junit.framework.TestCase;
-
 import com.google.gson.common.TestTypes.BagOfPrimitives;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonReader;
+import junit.framework.TestCase;
+
+import java.io.CharArrayReader;
+import java.io.CharArrayWriter;
+import java.io.StringReader;
 
 /**
  * Unit test for {@link JsonParser}

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2010 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.google.gson.stream;
 
 import java.io.EOFException;
@@ -32,6 +16,8 @@ import static com.google.gson.stream.JsonToken.NAME;
 import static com.google.gson.stream.JsonToken.NULL;
 import static com.google.gson.stream.JsonToken.NUMBER;
 import static com.google.gson.stream.JsonToken.STRING;
+
+import static com.google.gson.stream.JsonToken.*;
 
 @SuppressWarnings("resource")
 public final class JsonReaderTest extends TestCase {

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1,21 +1,28 @@
+/*
+ * Copyright (C) 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.gson.stream;
+
+import junit.framework.TestCase;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Arrays;
-import junit.framework.TestCase;
-
-import static com.google.gson.stream.JsonToken.BEGIN_ARRAY;
-import static com.google.gson.stream.JsonToken.BEGIN_OBJECT;
-import static com.google.gson.stream.JsonToken.BOOLEAN;
-import static com.google.gson.stream.JsonToken.END_ARRAY;
-import static com.google.gson.stream.JsonToken.END_OBJECT;
-import static com.google.gson.stream.JsonToken.NAME;
-import static com.google.gson.stream.JsonToken.NULL;
-import static com.google.gson.stream.JsonToken.NUMBER;
-import static com.google.gson.stream.JsonToken.STRING;
 
 import static com.google.gson.stream.JsonToken.*;
 


### PR DESCRIPTION
Improve code coverage tests for  ISO8601Utils::parse, fixes #5 .
Tests are implemented in the test method testIncreaseCoverageParseMethod in src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java.

Branch coverage before: 67% (according to JaCoCo).
Brach coverage after implementing two tests for uncovered switch cases: 70%
(Note: JaCoCo doesn't report coverage for custom thrown exceptions)
