### PR TITLE
Issue/30

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -148,13 +148,13 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     };
   }
 
+  //Method for refactoring
   public boolean excludeField(Field field, boolean serialize) {
     if ((modifiers & field.getModifiers()) != 0) {
       return true;
     }
 
-    if (version != Excluder.IGNORE_VERSIONS
-        && !isValidVersion(field.getAnnotation(Since.class), field.getAnnotation(Until.class))) {
+    if (isVersion(field)) {
       return true;
     }
 
@@ -164,7 +164,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
 
     if (requireExpose) {
       Expose annotation = field.getAnnotation(Expose.class);
-      if (annotation == null || (serialize ? !annotation.serialize() : !annotation.deserialize())) {
+      if (isAnnotation(serialize, annotation)) {
         return true;
       }
     }
@@ -178,6 +178,17 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     }
 
     List<ExclusionStrategy> list = serialize ? serializationStrategies : deserializationStrategies;
+    if (isExtracted(field, list)) return true;
+
+    return false;
+  }
+
+  // Refactored: Separation from excludeField method to decrease complexity.
+  private boolean isVersion(Field field) {
+    return version != Excluder.IGNORE_VERSIONS && !isValidVersion(field.getAnnotation(Since.class), field.getAnnotation(Until.class));
+  }
+  // Refactored: Separation from excludeField method to decrease complexity.
+  private boolean isExtracted(Field field, List<ExclusionStrategy> list) {
     if (!list.isEmpty()) {
       FieldAttributes fieldAttributes = new FieldAttributes(field);
       for (ExclusionStrategy exclusionStrategy : list) {
@@ -186,8 +197,12 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
         }
       }
     }
-
     return false;
+  }
+
+  // Refactored: Separation from excludeField method to decrease complexity.
+  private boolean isAnnotation(boolean serialize, Expose annotation) {
+    return annotation == null || (serialize ? !annotation.serialize() : !annotation.deserialize());
   }
 
   private boolean excludeClassChecks(Class<?> clazz) {


### PR DESCRIPTION
4.2.1 P+ Individual Refactor (Binxin): Point 2 - Refactor JsonReader::readEscapeCharacter(), fixes #30.
CC **before**: 23 CC **after**: 3. CC decreased by 87%.
1) Entire switch-case extracted into two external methods. First method returnEscape() uses a hashmap that takes care of consistent cases and return the value.
2) Second switch-case method getResult() takes care of the edge statements.