### PR TITLE
test #32: Add tests to increase branch coverage

### DIFF
--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1606,6 +1606,28 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
+  /**
+   * Check if value with unquoted name is skipped
+   * @throws IOException
+   */
+  public void testSkipUnquotedName() throws IOException {
+    JsonReader reader = new JsonReader(reader("{ name: \"name\"}"));
+    reader.setLenient(true);
+    reader.skipValue();
+    assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+  }
+
+  /**
+   * Check if value with single quoted name is skipped
+   * @throws IOException
+   */
+  public void testSkipSingleQuotedName() throws IOException {
+    JsonReader reader = new JsonReader(reader("{ 'name': \"name\"}"));
+    reader.setLenient(true);
+    reader.skipValue();
+    assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+  }
+
   public void testStringAsNumberWithTruncatedExponent() throws IOException {
     JsonReader reader = new JsonReader(reader("[123e]"));
     reader.setLenient(true);

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1606,6 +1606,34 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
+  /**
+   * Check if value with unquoted name is skipped
+   * Note that lenient is set to true for the tested JSON object.
+   * The reason is because single quoted numbers are usually not
+   * valid as numbers in JSON objects, but in this case it is acceptable.
+   * @throws IOException
+   */
+  public void testSkipUnquotedName() throws IOException {
+    JsonReader reader = new JsonReader(reader("{ name: \"name\"}"));
+    reader.setLenient(true);
+    reader.skipValue();
+    assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+  }
+
+  /**
+   * Check if value with single quoted name is skipped
+   * Note that lenient is set to true for the tested JSON object.
+   * The reason is because single quoted numbers are usually not
+   * valid as numbers in JSON objects, but in this case it is acceptable.
+   * @throws IOException
+   */
+  public void testSkipSingleQuotedName() throws IOException {
+    JsonReader reader = new JsonReader(reader("{ 'name': \"name\"}"));
+    reader.setLenient(true);
+    reader.skipValue();
+    assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+  }
+
   public void testStringAsNumberWithTruncatedExponent() throws IOException {
     JsonReader reader = new JsonReader(reader("[123e]"));
     reader.setLenient(true);


### PR DESCRIPTION
Resolves #32.

Increases branch coverage of `JsonReader::skipValue` from 92% (24/26) to 100%.
